### PR TITLE
[ISSUE_14] - [CODE] - Erro na PapelMoedaInvalidaException v2

### DIFF
--- a/code/core/TicketMachine.class
+++ b/code/core/TicketMachine.class
@@ -1,6 +1,3 @@
-// Source code is decompiled from a .class file using FernFlower decompiler.
-package br.calebe.ticketmachine.core;
-
 import br.calebe.ticketmachine.exception.PapelMoedaInvalidaException;
 import br.calebe.ticketmachine.exception.SaldoInsuficienteException;
 import java.util.Iterator;
@@ -18,7 +15,7 @@ public class TicketMachine {
    public void inserir(int quantia) throws PapelMoedaInvalidaException {
       boolean achou = false;
 
-      for(int i = 0; i < this.papelMoeda.length && !achou; ++i) {
+      for (int i = 0; i < this.papelMoeda.length && !achou; i++) {
          if (this.papelMoeda[i] == quantia) {
             achou = true;
          }
@@ -35,17 +32,21 @@ public class TicketMachine {
       return this.saldo;
    }
 
-   public Iterator<Integer> getTroco() {
-      return null;
+   public Iterator<PapelMoeda> getTroco() {
+      // Retornar um iterator de Troco correto usando o saldo atual
+      Troco troco = new Troco(saldo);
+      saldo = 0; // Zerar saldo após gerar o troco
+      return troco.getIterator();
    }
 
    public String imprimir() throws SaldoInsuficienteException {
       if (this.saldo < this.valor) {
          throw new SaldoInsuficienteException();
       } else {
+         this.saldo -= this.valor; // Deduz o valor do bilhete do saldo
          String result = "*****************\n";
-         result = result + "*** R$ " + this.saldo + ",00 ****\n";
-         result = result + "*****************\n";
+         result += "*** R$ " + this.valor + ",00 ****\n"; // Exibir valor do bilhete, não o saldo
+         result += "*****************\n";
          return result;
       }
    }

--- a/code/core/TicketMachine.class
+++ b/code/core/TicketMachine.class
@@ -1,3 +1,5 @@
+// Source code is decompiled from a .class file using FernFlower decompiler.
+package br.calebe.ticketmachine.core;
 import br.calebe.ticketmachine.exception.PapelMoedaInvalidaException;
 import br.calebe.ticketmachine.exception.SaldoInsuficienteException;
 import java.util.Iterator;


### PR DESCRIPTION
Modificar o laço para que ele subtraia o valor da nota a cada iteração, permitindo que o cálculo do troco prossiga corretamente para denominações menores.

Localização do Código:

O erro ocorre na falta da classe PapelMoedaInvalidaException. Ela deveria estar no pacote br.calebe.ticketmachine.exception.

Comportamento Esperado:

O método deve calcular corretamente a quantidade de cada nota para o valor do troco, atualizando o valor restante conforme as notas são contabilizadas.

Comportamento Atual:

O método apenas incrementa o contador de notas sem subtrair o valor da nota de valor, o que leva a um loop incorreto ou indefinido.